### PR TITLE
fix IE11 script issue

### DIFF
--- a/Core/view/base/web/my/all.js
+++ b/Core/view/base/web/my/all.js
@@ -117,7 +117,7 @@ define([
 	 * 2017-07-30
 	 * @returns {Boolean}
 	 */
-	,isLocalhost() {return -1 !== window.location.hostname.indexOf('localhost');}
+	,isLocalhost : function () {return -1 !== window.location.hostname.indexOf('localhost');}
 	/**
 	 * 2017-03-08
 	 * @used-by tr()

--- a/Core/view/base/web/my/string.js
+++ b/Core/view/base/web/my/string.js
@@ -66,7 +66,7 @@ define(['df-lodash', 'df-uniform', 'jquery'], function(_, uniform, $) {return {
 	 * @param {String} s
 	 * @returns {String}
 	 */
-	normalizePhone(s) {return '+' + s.replace(/[\s+\-()]/g, '');},
+	normalizePhone: function (s) {return '+' + s.replace(/[\s+\-()]/g, '');},
 	/**
 	 * 2015-11-04
 	 * Вставляет подстроку newChunk в заданное место position строки string.


### PR DESCRIPTION
We observed Internet Explorer 11 to have issues with some of the JS in mage2pro/core when it is used within mage2pro/stripe. We have prepared a small patch to the scripts to fix this issue and found it worked well in our tests.