### PR TITLE
Layout issue at admin magento 2 report panel

### DIFF
--- a/Framework/Plugin/Data/Form/Element/AbstractElement.php
+++ b/Framework/Plugin/Data/Form/Element/AbstractElement.php
@@ -138,7 +138,7 @@ class AbstractElement extends Sb {
 				$idSuffix = 0;
 			}
 			/** @var string[] $classA */
-			$classA = ['label', "admin__field-label', 'df-element-{$sb->getType()}"];
+			$classA = ['label', "admin__field-label df-element-{$sb->getType()}"];
 			if (df_starts_with($label, 'fa-')) {
 				$classA = array_merge($classA, ['fa', $label]);
 				$label = '';


### PR DESCRIPTION
Code mistake found at line 141.
unnecessary ',' found.
it effect at admin side at magento 2 report of any of order invoice grid layout.